### PR TITLE
including <math.h> in order to use sqrt function

### DIFF
--- a/Assignment-07/assignment7.c
+++ b/Assignment-07/assignment7.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-
+#include <math.h>
 
 int main(void)
 {


### PR DESCRIPTION
Making correction of assignment 7
To use **sqrt** function we must include _<math.h>_  or we have to define our own
It's easy to include so I did.